### PR TITLE
Kubernetes specific cloudwatch exporter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+config.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-config.yaml
+config.yml

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 config.yml
+target

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,6 @@ EXPOSE 9106
 
 WORKDIR /cloudwatch_exporter
 ADD . /cloudwatch_exporter
-RUN apt-get -qy update && apt-get -qy install maven && mvn package && \
-    mv target/cloudwatch_exporter-*-with-dependencies.jar /cloudwatch_exporter.jar && \
-    rm -rf /cloudwatch_exporter && apt-get -qy remove --purge maven && apt-get -qy autoremove
 WORKDIR /
 
 RUN mkdir /config

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,10 @@ FROM java
 MAINTAINER Prometheus Team <prometheus-developers@googlegroups.com>
 EXPOSE 9106
 
-WORKDIR /cloudwatch_exporter
-ADD . /cloudwatch_exporter
 WORKDIR /
 
 RUN mkdir /config
 
 ADD config.yml /config/
-ADD target/cloudwatch_exporter-0.5-SNAPSHOT.jar /cloudwatch_exporter.jar
+ADD target/cloudwatch_exporter-0.5-SNAPSHOT-jar-with-dependencies.jar /cloudwatch_exporter.jar
 ENTRYPOINT [ "java", "-jar", "/cloudwatch_exporter.jar", "9106", "/config/config.yml" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,5 @@ WORKDIR /
 RUN mkdir /config
 
 ADD config.yml /config/
+ADD target/cloudwatch_exporter-0.5-SNAPSHOT.jar /cloudwatch_exporter.jar
 ENTRYPOINT [ "java", "-jar", "/cloudwatch_exporter.jar", "9106", "/config/config.yml" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,5 @@ WORKDIR /
 
 RUN mkdir /config
 
-ONBUILD ADD config.yml /config/
+ADD config.yml /config/
 ENTRYPOINT [ "java", "-jar", "/cloudwatch_exporter.jar", "9106", "/config/config.yml" ]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 CloudWatch Exporter
 =====
 
+## Deploying to Kubernetes
+
 An exporter for [Amazon CloudWatch](http://aws.amazon.com/cloudwatch/), for Prometheus.
 
 ## Building and running

--- a/README.md
+++ b/README.md
@@ -5,7 +5,10 @@ An exporter for [Amazon CloudWatch](http://aws.amazon.com/cloudwatch/), for Prom
 ## Deploying to Kubernetes
 
 - Edit `config.yml`
-- Deploy using `./deploy/deploy.sh`
+- Deploy using
+```
+./deploy/deploy.sh
+```
 
 ## Building and running
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 CloudWatch Exporter
 =====
+An exporter for [Amazon CloudWatch](http://aws.amazon.com/cloudwatch/), for Prometheus.
 
 ## Deploying to Kubernetes
 
-An exporter for [Amazon CloudWatch](http://aws.amazon.com/cloudwatch/), for Prometheus.
+- Edit `config.yml`
+- Deploy using `./deploy/deploy.sh`
 
 ## Building and running
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ An exporter for [Amazon CloudWatch](http://aws.amazon.com/cloudwatch/), for Prom
 ```
 export AWS_ACCESS_KEY_ID='sample-aws-access-key'
 export AWS_SECRET_ACCESS_KEY='sample-aws-access-secret'
+export NAMESPACE='sample-namespace-to-deploy'
+export ORG='sample-container-registry-org'
+export IMAGE_NAME='sample-exporter-image-name'
+export IMAGE_SECRET='sample-k8s-deployment-image-secret'
+export M2_DIR='/home/ubuntu/.m2'
+export BUILD_IMAGE_NAME='sample-java-image-to-use-for-build'
+
 ./deploy/deploy.sh
 ```
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ An exporter for [Amazon CloudWatch](http://aws.amazon.com/cloudwatch/), for Prom
 - Edit `config.yml`
 - Deploy using
 ```
+export AWS_ACCESS_KEY_ID='sample-aws-access-key'
+export AWS_SECRET_ACCESS_KEY='sample-aws-access-secret'
 ./deploy/deploy.sh
 ```
 

--- a/deploy/.gitignore
+++ b/deploy/.gitignore
@@ -1,0 +1,1 @@
+deployment.yaml

--- a/deploy/.gitignore
+++ b/deploy/.gitignore
@@ -1,1 +1,3 @@
 deployment.yaml
+service-monitor.yaml
+service.yaml

--- a/deploy/build.sh
+++ b/deploy/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash 
+cd /cloudwatch_exporter
+mvn package -Dmaven.test.skip=true

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -35,10 +35,10 @@ sed -i "s#{{aws_secret_access_key}}#${AWS_SECRET_ACCESS_KEY}#g" ${DEPLOYMENT_YAM
 sed -i "s#{{image_secret}}#${IMAGE_SECRET}#g" ${DEPLOYMENT_YAML}
 
 echo "Rolling update first status"
-kubectl apply -f ${DEPLOYMENT_YAML}
-kubectl apply -f ${SERVICE_YAML}
-kubectl apply -f ${SERVICE_MONITOR_YAML}
-kubectl get pods -n ${NAMESPACE}
+kubectl --context=k8sd.practodev.com apply -f ${DEPLOYMENT_YAML}
+kubectl --context=k8sd.practodev.com apply -f ${SERVICE_YAML}
+kubectl --context=k8sd.practodev.com apply -f ${SERVICE_MONITOR_YAML}
+kubectl --context=k8sd.practodev.com get pods -n ${NAMESPACE}
 
 echo "Check rollout status using"
 echo "kubectl get pods -n ${NAMESPACE}"

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -e
+
+GIT_UNTRACKED_FILES=`git ls-files --others --exclude-standard | wc -l`
+GIT_UNSTAGED_DIFF=`git diff --no-ext-diff | wc -l`
+GIT_STAGED_DIFF=`git diff-index --cached HEAD -- | wc -l`
+NAMESPACE='monitoring'
+ORG='practodev'
+IMAGE_NAME='cloudwatch-exporter'
+IMAGE_SECRET='dev-secret-docker'
+DEPLOYMENT_YAML='deploy/deployment.yaml'
+
+if [[ $GIT_UNTRACKED_FILES -ne 0 || ${GIT_UNSTAGED_DIFF} -ne 0 || ${GIT_STAGED_DIFF} -ne 0 ]]; then
+    echo "[ERROR]: Deployment not started as there are local changes"
+    exit 1
+fi
+
+echo "Pulling latest code"
+git pull origin master
+
+echo "Building image"
+TAG=`git rev-parse HEAD`
+docker build -t ${IMAGE_NAME}:${TAG} .
+
+echo "Pushing new image"
+docker push ${IMAGE_NAME}:${TAG}
+
+echo "Creating new deployment yaml"
+cp deploy/deployment.sample.yaml ${DEPLOYMENT_YAML}
+sed -i "s#{{tag}}#${TAG}#g" ${DEPLOYMENT_YAML}
+sed -i "s#{{org}}#${ORG}#g" ${DEPLOYMENT_YAML}
+sed -i "s#{{aws_acess_key_id}}#${AWS_ACCESS_KEY_ID}#g" ${DEPLOYMENT_YAML}
+sed -i "s#{{aws_secret_access_key}}#${AWS_SECRET_ACCESS_KEY}#g" ${DEPLOYMENT_YAML}
+sed -i "s#{{image_secret}}#${IMAGE_SECRET}g" ${DEPLOYMENT_YAML}
+
+echo "Rolling update first status"
+kubectl apply -f ${DEPLOYMENT_YAML}
+kubectl get pods -n ${NAMESPACE} | grep cloudwatch
+
+echo "Check rollout status using"
+echo kubectl get pods -n ${NAMESPACE} 

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -13,8 +13,9 @@ echo "Pulling latest code"
 #git pull origin master
 
 echo "Building image"
+echo `pwd`
 TAG=`git rev-parse HEAD`
-docker run -v `pwd`:/cloudwatch_exporter -v $M2_DIR:/root/.m2 ${ORG}/${BUILD_IMAGE_NAME} /bin/bash /cloudwatch_exporter/deploy/build.sh
+docker run -v `pwd`:/cloudwatch_exporter -v ${M2_DIR}:/root/.m2 ${ORG}/${BUILD_IMAGE_NAME} /bin/bash /cloudwatch_exporter/deploy/build.sh
 docker build -t ${ORG}/${IMAGE_NAME}:${TAG} .
 
 echo "Pushing new image"

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -10,6 +10,8 @@ ORG='practodev'
 IMAGE_NAME='cloudwatch-exporter'
 IMAGE_SECRET='dev-secret-docker'
 DEPLOYMENT_YAML='deploy/deployment.yaml'
+SERVICE_YAML='deploy/service.yaml'
+SERVICE_MONITOR_YAML='deploy/service-monitor.yaml'
 
 echo "Pulling latest code"
 #git pull origin master
@@ -21,8 +23,11 @@ docker build -t ${ORG}/${IMAGE_NAME}:${TAG} .
 echo "Pushing new image"
 docker push ${ORG}/${IMAGE_NAME}:${TAG}
 
-echo "Creating new deployment yaml"
+echo "Creating yamls"
 cp deploy/deployment.sample.yaml ${DEPLOYMENT_YAML}
+cp deploy/service.sample.yaml ${SERVICE_YAML}
+cp deploy/service-monitor.sample.yaml ${SERVICE_MONITOR_YAML}
+
 sed -i "s#{{tag}}#${TAG}#g" ${DEPLOYMENT_YAML}
 sed -i "s#{{org}}#${ORG}#g" ${DEPLOYMENT_YAML}
 sed -i "s#{{aws_access_key_id}}#${AWS_ACCESS_KEY_ID}#g" ${DEPLOYMENT_YAML}
@@ -31,7 +36,9 @@ sed -i "s#{{image_secret}}#${IMAGE_SECRET}#g" ${DEPLOYMENT_YAML}
 
 echo "Rolling update first status"
 kubectl apply -f ${DEPLOYMENT_YAML}
-kubectl get pods -n ${NAMESPACE} | grep cloudwatch
+kubectl apply -f ${SERVICE_YAML}
+kubectl apply -f ${SERVICE_MONITOR_YAML}
+kubectl get pods -n ${NAMESPACE}
 
 echo "Check rollout status using"
-echo kubectl get pods -n ${NAMESPACE} | grep cloudwatch 
+echo "kubectl get pods -n ${NAMESPACE}"

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -5,10 +5,6 @@ set -e
 GIT_UNTRACKED_FILES=`git ls-files --others --exclude-standard | wc -l`
 GIT_UNSTAGED_DIFF=`git diff --no-ext-diff | wc -l`
 GIT_STAGED_DIFF=`git diff-index --cached HEAD -- | wc -l`
-NAMESPACE='monitoring'
-ORG='practodev'
-IMAGE_NAME='cloudwatch-exporter'
-IMAGE_SECRET='dev-secret-docker'
 DEPLOYMENT_YAML='deploy/deployment.yaml'
 SERVICE_YAML='deploy/service.yaml'
 SERVICE_MONITOR_YAML='deploy/service-monitor.yaml'
@@ -18,6 +14,7 @@ echo "Pulling latest code"
 
 echo "Building image"
 TAG=`git rev-parse HEAD`
+docker run -v `pwd`:/cloudwatch_exporter -v $M2_DIR:/root/.m2 ${ORG}/${BUILD_IMAGE_NAME} /bin/bash /cloudwatch_exporter/deploy/build.sh
 docker build -t ${ORG}/${IMAGE_NAME}:${TAG} .
 
 echo "Pushing new image"

--- a/deploy/deployment.sample.yaml
+++ b/deploy/deployment.sample.yaml
@@ -17,7 +17,7 @@ spec:
     metadata:
       labels:
         app: prometheus-cloudwatch-exporter 
-        version: 0.4
+        version: "0.4"
     spec:
       containers:
       - env:
@@ -27,7 +27,7 @@ spec:
           value: {{aws_secret_access_key}}
         image: {{org}}/cloudwatch-exporter:{{tag}}
         imagePullPolicy: IfNotPresent
-        name: voice-67b3b31
+        name: prometheus-cloudwatch-exporter 
         ports:
         - containerPort: 9106
           protocol: TCP
@@ -41,8 +41,6 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
       dnsPolicy: ClusterFirst
-      imagePullSecrets:
-      - name: {{image_secret}}
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext: {}

--- a/deploy/deployment.sample.yaml
+++ b/deploy/deployment.sample.yaml
@@ -5,7 +5,7 @@ metadata:
     app: prometheus-cloudwatch-exporter 
     version: "0.4" 
   name: prometheus-cloudwatch-exporter
-  namespace: monitoring
+  namespace: central 
 spec:
   replicas: 1
   strategy:
@@ -41,6 +41,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
       dnsPolicy: ClusterFirst
+      imagePullSecrets:
+      - name: {{image_secret}} 
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext: {}

--- a/deploy/deployment.sample.yaml
+++ b/deploy/deployment.sample.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   labels:
     app: prometheus-cloudwatch-exporter 
-    version: latest
+    version: "0.4" 
   name: prometheus-cloudwatch-exporter
   namespace: monitoring
 spec:

--- a/deploy/deployment.yaml.sample
+++ b/deploy/deployment.yaml.sample
@@ -1,0 +1,49 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: prometheus-cloudwatch-exporter 
+    version: latest
+  name: prometheus-cloudwatch-exporter
+  namespace: monitoring
+spec:
+  replicas: 1
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: prometheus-cloudwatch-exporter 
+        version: 0.4
+    spec:
+      containers:
+      - env:
+        - name: AWS_ACCESS_KEY_ID 
+          value: {{aws_access_key_id}}
+        - name: AWS_SECRET_ACCESS_KEY
+          value: {{aws_secret_access_key}}
+        image: {{org}}/cloudwatch-exporter:{{tag}}
+        imagePullPolicy: IfNotPresent
+        name: voice-67b3b31
+        ports:
+        - containerPort: 9106
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 200m
+            memory: 600Mi
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      imagePullSecrets:
+      - name: {{image_secret}}
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30

--- a/deploy/service-monitor.sample.yaml
+++ b/deploy/service-monitor.sample.yaml
@@ -1,0 +1,19 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  namespace: monitoring
+  name: prometheus-cloudwatch-servicemonitor
+  labels:
+    k8s-apps: http
+spec:
+  jobLabel: k8s-app
+  selector:
+    matchExpressions:
+    - {key: k8s-app, operator: Exists}
+  namespaceSelector:
+    matchNames:
+    - kube-system
+    - monitoring
+  endpoints:
+  - port: sqs-metrics
+    interval: 15s

--- a/deploy/service-monitor.sample.yaml
+++ b/deploy/service-monitor.sample.yaml
@@ -2,17 +2,15 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   namespace: monitoring
-  name: cloudwatch-exporter
+  name: cloudwatch-monitor
   labels:
-    k8s-app: cloudwatch-exporter
+    k8s-app: cloudwatch-monitor
 spec:
-  jobLabel: app
   selector:
     matchLabels:
       app: prometheus-cloudwatch-exporter 
   namespaceSelector:
-    matchNames:
-    - monitoring
+    any: true
   endpoints:
   - port: sqs-metrics
     interval: 30s

--- a/deploy/service-monitor.sample.yaml
+++ b/deploy/service-monitor.sample.yaml
@@ -2,18 +2,17 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   namespace: monitoring
-  name: prometheus-cloudwatch-servicemonitor
+  name: cloudwatch-exporter
   labels:
-    k8s-apps: http
+    k8s-app: cloudwatch-exporter
 spec:
-  jobLabel: k8s-app
+  jobLabel: app
   selector:
-    matchExpressions:
-    - {key: k8s-app, operator: Exists}
+    matchLabels:
+      app: prometheus-cloudwatch-exporter 
   namespaceSelector:
     matchNames:
-    - kube-system
     - monitoring
   endpoints:
   - port: sqs-metrics
-    interval: 15s
+    interval: 30s

--- a/deploy/service.sample.yaml
+++ b/deploy/service.sample.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: monitoring
+  namespace: central 
   labels:
     app: prometheus-cloudwatch-exporter
     version: "0.4"

--- a/deploy/service.sample.yaml
+++ b/deploy/service.sample.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: monitoring
+  labels:
+    app: prometheus-cloudwatch-exporter
+    version: "0.4"
+  annotations:
+    alpha.monitoring.coreos.com/non-namespaced: "true"
+  name: prometheus-cloudwatch-exporter
+spec:
+  ports:
+  - name: sqs-metrics
+    port: 9106
+    targetPort: 9106 
+    protocol: TCP
+  selector:
+    app: prometheus-cloudwatch-exporter 

--- a/example.yml
+++ b/example.yml
@@ -140,3 +140,8 @@ metrics:
   aws_metric_name: WriteIOPS
   aws_dimensions: [NodeID, ClusterIdentifier]
   aws_statistics: [Average]
+
+- aws_namespace: AWS/SQS
+  aws_metric_name: ApproximateNumberOfMessagesVisible
+  aws_dimensions: [QueueName]
+  aws_statistics: [Average]

--- a/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
+++ b/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
@@ -115,9 +115,11 @@ public class CloudWatchCollector extends Collector {
           defaultDelay = ((Number)config.get("delay_seconds")).intValue();
         }
 
-        prometheusMetricNamePrefix = safeName((String)config.get("aws_namespace").toLowerCase() + "_" + toSnakeCase(config.get("aws_metric_name")));
+	String prometheusMetricNamePrefix = safeName(((String) config.get("aws_namespace")).toLowerCase() + "_" + toSnakeCase((String) config.get("aws_metric_name")));
+
+      // String prometheusMetricNamePrefix = safeName(((String) config.get("aws_namespace")).toLowerCase() + "_" + toSnakeCase(((String) config.get("aws_metric_name")).string()));
         if (config.containsKey("prometheus_metric_name_prefix")) {
-            prometheusMetricNamePrefix = ((String)config.get("prometheus_metric_name_prefix")).string();
+            prometheusMetricNamePrefix = ((String) config.get("prometheus_metric_name_prefix"));
         }
 
         if (client == null) {

--- a/src/test/java/io/prometheus/cloudwatch/CloudWatchCollectorTest.java
+++ b/src/test/java/io/prometheus/cloudwatch/CloudWatchCollectorTest.java
@@ -130,7 +130,7 @@ public class CloudWatchCollectorTest {
   @Test
   public void testMetricPeriod() {
     new CloudWatchCollector(
-            "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/ELB\n  aws_metric_name: RequestCount\n  period_seconds: 100\n  range_seconds: 200\n  delay_seconds: 300", client).register(registry);
+            "---\nregion: reg\nmetrics:\n- aws_namespace: AWS/ELB\n  aws_metric_name: RequestCount\n  period_seconds: 100\n  range_seconds: 200\n  delay_seconds: 300\n  prometheus_metric_name_prefix: aws_elb_mylb", client).register(registry);
 
     Mockito.when(client.getMetricStatistics((GetMetricStatisticsRequest) anyObject()))
             .thenReturn(new GetMetricStatisticsResult());


### PR DESCRIPTION
**What?**

There were few changes made in the upstream cloudwatch exporter to make it more useful for kubernetes. Following were changed

- Added `prometheus_metric_base_name` as a feature. This was done as HPA does not have a feature to properly integrate with prometheus for all use cases. Details on the use case is here - https://github.com/prometheus/cloudwatch_exporter/issues/83#issuecomment-353800877
- One command for building and deploying to kubernetes `./deploy/deploy.sh`
